### PR TITLE
Use button tag for button_submit_tag

### DIFF
--- a/lib/css3buttons/helpers/button_helper.rb
+++ b/lib/css3buttons/helpers/button_helper.rb
@@ -3,6 +3,7 @@ module Css3buttons
     module ButtonHelper
       include ActionView::Helpers::UrlHelper
       include ActionView::Helpers::FormTagHelper
+      include ActionView::Helpers::TagHelper
       def method_missing(method, *args)
         if method.to_s.index("button_link_to") || method.to_s.index("button_submit_tag")
           qualifiers = ["primary", "big", "positive", "negative", "pill", "danger", "safe", "button"]
@@ -32,7 +33,7 @@ module Css3buttons
             if is_link_method?(method)
               link_to(label, link, options)
             else
-              submit_tag(label, options)
+              content_tag :button, label, { "type" => "submit", "name" => "commit", "value" => "commit" }.update(options.stringify_keys)
             end
           end
         else

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,7 @@
 # css3buttons gem - helper methods for css3buttons
 
+This fork: Use button tag for button_submit_tag, so that icons are used.
+
 The css3buttons gem is a small set of helper methods designed to work in
 conjunction with the __amazing__ [css3 github buttons by Nicolas Gallagher](http://nicolasgallagher.com/lab/css3-github-buttons/).
 

--- a/spec/button_helper_spec.rb
+++ b/spec/button_helper_spec.rb
@@ -22,7 +22,7 @@ describe Css3buttons::Helpers::ButtonHelper do
   it "should create basic submit buttons" do
     button = html(button_submit_tag(@label))
     
-    button.should have_selector("input.button[type='submit']")
+    button.should have_selector("button.button[type='submit']")
     @qualifiers.each do |qualifier|
       button.should_not have_selector("input.#{qualifier}")
     end
@@ -45,7 +45,7 @@ describe Css3buttons::Helpers::ButtonHelper do
 
   it "should create positive submit buttons" do
     button = html(positive_button_submit_tag(@label))
-    button.should have_selector("input.button.safe[type='submit']")
+    button.should have_selector("button.button.safe[type='submit']")
     @qualifiers.each do |qualifier|
       button.should_not have_selector("input.#{qualifier}") unless qualifier == "safe"
     end
@@ -61,7 +61,7 @@ describe Css3buttons::Helpers::ButtonHelper do
 
   it "should create positive submit buttons" do
     button = html(negative_button_submit_tag(@label))
-    button.should have_selector("input.button.danger[type='submit']")
+    button.should have_selector("button.button.danger[type='submit']")
     @qualifiers.each do |qualifier|
       button.should_not have_selector("a.#{qualifier}") unless qualifier == "danger"
     end
@@ -97,7 +97,7 @@ describe Css3buttons::Helpers::ButtonHelper do
 
   it "should create pill submit buttons" do
     button = html(pill_button_submit_tag(@label))
-    button.should have_selector("input.button.pill[type='submit']")
+    button.should have_selector("button.button.pill[type='submit']")
     @qualifiers.each do |qualifier|
       button.should_not have_selector("input.#{qualifier}") unless qualifier == "pill"
     end
@@ -121,7 +121,7 @@ describe Css3buttons::Helpers::ButtonHelper do
 
   it "should create positive pill submit buttons" do
     button = html(positive_pill_button_submit_tag(@label))
-    button.should have_selector("input.button.pill.safe[type='submit']")
+    button.should have_selector("button.button.pill.safe[type='submit']")
     button.should_not have_selector("input.danger")
   end
 
@@ -133,7 +133,7 @@ describe Css3buttons::Helpers::ButtonHelper do
 
   it "should create negative pill submit buttons" do
     button = html(negative_pill_button_submit_tag(@label))
-    button.should have_selector("input.button.pill.danger[type='submit']")
+    button.should have_selector("button.button.pill.danger[type='submit']")
     button.should_not have_selector("input.safe")
   end
 


### PR DESCRIPTION
https://github.com/necolas/css3-github-buttons
says:
"A range of icons can be added (only for links and buttons)"

This diff uses button tag instead of input tag so that the icons are shown on *_button_submit_tag
