### PR TITLE
Minor button group rendered as button group

### DIFF
--- a/lib/css3buttons/button_group.rb
+++ b/lib/css3buttons/button_group.rb
@@ -13,7 +13,6 @@ module Css3buttons
     def render(&block)
       html_options = @options
       html_options.delete(:wrapper_tag)
-      html_options.delete(:minor)
       html_options[:class] ||= ''
       html_options[:class] = (html_options[:class].split(" ") + ['button-group']).join(" ")
       html_options[:class] = (html_options[:class].split(" ") + ['minor-group']).join(" ") if @options[:minor]

--- a/lib/css3buttons/button_group.rb
+++ b/lib/css3buttons/button_group.rb
@@ -16,6 +16,7 @@ module Css3buttons
       html_options[:class] ||= ''
       html_options[:class] = (html_options[:class].split(" ") + ['button-group']).join(" ")
       html_options[:class] = (html_options[:class].split(" ") + ['minor-group']).join(" ") if @options[:minor]
+      html_options.delete(:minor)
       content_tag(:div, @template.capture(&block), html_options) if block_given?
     end
   end


### PR DESCRIPTION
Thetron, 

I love your gem! I am writing a backend administrative interface, and those buttons are just what I needed. 
I did notice that my minor button groups where being rendered as regular button groups. 

The output was:
```<div class="button-group">

``````
when it should have been:
```<div class="button-group minor-group">
``````

I forked and made a 1 line change, and I think that fixes the problem. Please review. 
(I was going to write some test, but I am not familiar with rspec).

Thanks for making your gem available.
