### PR TITLE
Fixed Background images not showing up

### DIFF
--- a/lib/generators/css3buttons/templates/public/stylesheets/css3-github-buttons.css
+++ b/lib/generators/css3buttons/templates/public/stylesheets/css3-github-buttons.css
@@ -81,7 +81,7 @@ http://github.com/necolas/css3-github-buttons
     width: 12px; 
     height: 12px; 
     margin: 0 0.75em 0 -0.25em; 
-    background: url(gh-icons.png) 0 99px no-repeat;
+    background: url(../../images/css3buttons/css3-github-buttons-icons.png) 0 99px no-repeat;
 }
 
 .button.arrowup.icon:before { background-position: 0 0; }


### PR DESCRIPTION
Thanks for the excellent work done. I noticed the CSS was still referencing to the original bg image name and path and i fixed it with the new path generated by your gem 

background: url(../../images/css3buttons/css3-github-buttons-icons.png) 0 99px no-repeat;

Regards.
