### PR TITLE
Fixed routes for precompiled assets in 3.1

### DIFF
--- a/lib/assets/stylesheets/css3buttons/styles.css.scss
+++ b/lib/assets/stylesheets/css3buttons/styles.css.scss
@@ -81,7 +81,7 @@ http://github.com/necolas/css3-github-buttons
     width: 12px; 
     height: 12px; 
     margin: 0 0.75em 0 -0.25em; 
-    background: url(<%= asset_path "css3buttons/icons.png" %>) 0 99px no-repeat;
+    background: image-url("css3buttons/icons.png") 0 99px no-repeat;
 }
 
 .button.arrowup.icon:before { background-position: 0 0; }


### PR DESCRIPTION
Fixed image helper to the sprite file to work on 3.1 using scss instead of css.erb
